### PR TITLE
remove require pry from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'active_support/all'
 require 'action_controller'
 require 'action_dispatch'


### PR DESCRIPTION
running tests will result in a load error if pry is not already installed. Since its not being used, I think we can go ahead and get rid of it.